### PR TITLE
Update for python 3.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.vscode/
 
 # Spyder project settings
 .spyderproject

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
-packaging==20.8
-pytest==7.1.1
+iniconfig==2.0.0
+packaging==24.2
+pluggy==1.5.0
+pytest==8.3.4

--- a/tests/test_fizzbuzz.py
+++ b/tests/test_fizzbuzz.py
@@ -1,4 +1,3 @@
-import pytest
 from interviews.fizzbuzz import fizzbuzz
 
 def test_works_with_1():


### PR DESCRIPTION
[Asana Task](https://app.asana.com/0/1205655776549324/1209241074279180/f)

The repo isn't broken with Python 3.13.1, but it is displaying deprecation warnings when you try to run the tests. 

Changes
- Update requirements (pytest) to remove deprecation warnings when running tests. 
- requirements.txt now lists all dependencies that get installed along with pytest
- Update .gitignore to ignore .vscode user settings folder. 
- Remove unnecessary pytest import in test file.